### PR TITLE
get_studio_repo_url: Lazily instantiate`git_repo`.

### DIFF
--- a/src/dvc_studio_client/post_live_metrics.py
+++ b/src/dvc_studio_client/post_live_metrics.py
@@ -41,9 +41,10 @@ def _convert_to_studio_url(remote_url):
     return studio_url
 
 
-def get_studio_repo_url(git_repo) -> Optional[str]:
+def get_studio_repo_url() -> Optional[str]:
     studio_url = None
     try:
+        git_repo = Repo()
         remote_url = _get_remote_url(git_repo)
         studio_url = _convert_to_studio_url(remote_url)
     except GitError:
@@ -65,13 +66,14 @@ def get_studio_repo_url(git_repo) -> Optional[str]:
 
 def get_studio_token_and_repo_url():
     studio_token = getenv(STUDIO_TOKEN, None)
-    if not studio_token:
+    if studio_token is None:
         logger.debug("STUDIO_TOKEN not found. Skipping `post_studio_live_metrics`")
+        return None, None
 
     studio_repo_url = getenv(STUDIO_REPO_URL, None)
     if studio_repo_url is None:
         logger.debug(f"`{STUDIO_REPO_URL}` not found. Trying to automatically find it.")
-        studio_repo_url = get_studio_repo_url(Repo())
+        studio_repo_url = get_studio_repo_url()
     return studio_token, studio_repo_url
 
 

--- a/tests/test_post_live_metrics.py
+++ b/tests/test_post_live_metrics.py
@@ -9,6 +9,7 @@ from dvc_studio_client.post_live_metrics import (
     _convert_to_studio_url,
     _get_remote_url,
     get_studio_repo_url,
+    get_studio_token_and_repo_url,
     post_live_metrics,
 )
 
@@ -63,7 +64,7 @@ def test_get_studio_repo_url(caplog, mocker):
         side_effect=GitError(),
     )
     caplog.clear()
-    get_studio_repo_url(None)
+    get_studio_repo_url()
     assert caplog.records[0].message == (
         "Tried to find remote url for the active branch but failed.\n"
     )
@@ -78,7 +79,7 @@ def test_get_studio_repo_url(caplog, mocker):
         return_value="bad@repo:url",
     )
     caplog.clear()
-    get_studio_repo_url(None)
+    get_studio_repo_url()
     assert caplog.records[0].message == (
         "Found invalid remote url for the active branch.\n"
         f" Supported urls must start with any of {VALID_URLS}"
@@ -315,3 +316,10 @@ def test_post_live_metrics_bad_response(mocker, monkeypatch):
         )
         is False
     )
+
+
+def test_get_studio_token_and_repo_url_skip_repo_url(monkeypatch):
+    monkeypatch.setenv(STUDIO_REPO_URL, "FOO_REPO_URL")
+    token, repo_url = get_studio_token_and_repo_url()
+    assert token is None
+    assert repo_url is None  # Skipped call to get_repo_url


### PR DESCRIPTION
So `GitError` is handled `None` returned in case of trying to instantiate invalid `Repo`.

Don't call `get_studio_repo_url` unnecessarily inside `get_studio_token_and_repo_url`.