### PR TITLE
Support `metrics` on any event.

### DIFF
--- a/src/dvc_studio_client/post_live_metrics.py
+++ b/src/dvc_studio_client/post_live_metrics.py
@@ -135,13 +135,14 @@ def post_live_metrics(
     if params:
         body["params"] = params
 
+    if metrics:
+        body["metrics"] = metrics
+
     if event_type == "data":
         if step is None:
             logger.warning("Missing `step` in `data` event.")
             return None
         body["step"] = step
-        if metrics:
-            body["metrics"] = metrics
         if plots:
             body["plots"] = plots
 

--- a/src/dvc_studio_client/schema.py
+++ b/src/dvc_studio_client/schema.py
@@ -23,6 +23,7 @@ BASE_SCHEMA = Schema(
         "client": str,
         "errors": [ERROR_SCHEMA],
         "params": {str: dict},
+        "metrics": {str: {"data": dict, "error": ERROR_SCHEMA}},
         # Required("timestamp"): iso_datetime,  # TODO: decide if we need this
     }
 )
@@ -31,7 +32,6 @@ SCHEMAS_BY_TYPE = {
     "data": BASE_SCHEMA.extend(
         {
             Required("step"): int,
-            "metrics": {str: {"data": dict, "error": ERROR_SCHEMA}},
             "plots": {str: {"data": [dict], "props": dict, "error": ERROR_SCHEMA}},
         }
     ),

--- a/tests/test_post_live_metrics.py
+++ b/tests/test_post_live_metrics.py
@@ -262,6 +262,30 @@ def test_post_live_metrics_done(mocker, caplog, monkeypatch):
         timeout=5,
     )
 
+    assert post_live_metrics(
+        "done",
+        "f" * 40,
+        "fooname",
+        "fooclient",
+        metrics={"dvclive/metris.json": {"data": {"foo": 1}}},
+    )
+    mocked_post.assert_called_with(
+        "https://studio.iterative.ai/api/live",
+        json={
+            "type": "done",
+            "repo_url": "FOO_REPO_URL",
+            "baseline_sha": "f" * 40,
+            "name": "fooname",
+            "client": "fooclient",
+            "metrics": {"dvclive/metris.json": {"data": {"foo": 1}}},
+        },
+        headers={
+            "Authorization": "token FOO_TOKEN",
+            "Content-type": "application/json",
+        },
+        timeout=5,
+    )
+
 
 def test_post_live_metrics_bad_response(mocker, monkeypatch):
     monkeypatch.setenv(STUDIO_TOKEN, "FOO_TOKEN")


### PR DESCRIPTION
Needed to allow DVC to send `metrics` updates outside the stage where DVCLive is used. For example:

https://github.com/iterative/example-get-started-experiments/blob/982941e239db6a7628ab9d327e7424fdef09429e/dvc.yaml#L38-L40