### PR TITLE
Add leaked secrets scan workflow

### DIFF
--- a/.github/workflows/leaked-secrets-scan.yaml
+++ b/.github/workflows/leaked-secrets-scan.yaml
@@ -1,0 +1,24 @@
+name: Leaked Secrets Scan
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - main
+      - "[0-9]+.[0-9]+.x"
+  workflow_dispatch:
+jobs:
+  TruffleHog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@40868952497a035edd4833fad140a903b5cb4fe5
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --debug --only-verified


### PR DESCRIPTION
Changes:
- Move org-level Trufflehog required workflow to the repo level. This should solve the issues with stuck workflows that we've been facing