### PR TITLE
Migrate from PyPI tokens to Trusted Publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,16 +5,15 @@ on:
     types: [published]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  id-token: write
-
 env:
   FORCE_COLOR: "1"
 
 jobs:
   release:
     environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,16 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 env:
   FORCE_COLOR: "1"
 
 jobs:
   release:
+    environment: pypi
     runs-on: ubuntu-latest
     steps:
     - name: Check out the repository
@@ -36,5 +41,3 @@ jobs:
     - name: Upload package
       if: github.event_name == 'release'
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers#using-trusted-publishing-with-github-actions