### PR TITLE
Refactor Authorization to Authentication in codebase

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,8 @@ Features
 - Live Experiments
    - `post_live_metrics`_: Post updates to `api/live`.
 
-- Studio authorization
-    - `initiate_authorization`_: Initiates the authorization process for a client application
+- Studio authentication
+    - `get_access_token`_: Initiates the authentication process for a client application.
 
 Installation
 ------------
@@ -76,4 +76,4 @@ please `file an issue`_ along with a detailed description.
 .. _DVC Studio: https://dvc.org/doc/studio
 .. _get_download_uris: https://docs.iterative.ai/dvc-studio-client/reference/dvc_studio_client/model_registry/
 .. _post_live_metrics: https://docs.iterative.ai/dvc-studio-client/reference/dvc_studio_client/post_live_metrics/
-.. _initiate_authorization: https://docs.iterative.ai/dvc-studio-client/reference/dvc_studio_client/auth/
+.. _get_access_token: https://docs.iterative.ai/dvc-studio-client/reference/dvc_studio_client/auth/

--- a/src/dvc_studio_client/auth.py
+++ b/src/dvc_studio_client/auth.py
@@ -26,16 +26,16 @@ class InvalidScopesError(StudioAuthError):
     pass
 
 
-class AuthorizationExpired(StudioAuthError):
+class AuthenticationExpired(StudioAuthError):
     pass
 
 
 def get_access_token(
     *, hostname, token_name=None, scopes="", use_device_code=False, client_name="client"
 ):
-    """Initiate Authorization
+    """Initiate Authentication
 
-    This method initiates the authorization process for a client application.
+    This method initiates the authentication process for a client application.
     It generates a user code and a verification URI that the user needs to
     access in order to authorize the application.
 
@@ -45,7 +45,7 @@ def get_access_token(
         scopes (str, optional): A comma-separated string of scopes that
         the application requires. Default is empty.
         use_device_code (bool, optional): Whether to use the device code
-        flow for authorization. Default is False.
+        flow for authentication. Default is False.
         client_name (str, optional): Client name
 
     Returns:
@@ -85,7 +85,7 @@ def get_access_token(
         print(f"Please open the following url in your browser.\n{verification_uri}")
         print(f"And enter the user code below {user_code} to authorize.")
 
-    access_token = check_token_authorization(uri=token_uri, device_code=device_code)
+    access_token = check_token_authentication(uri=token_uri, device_code=device_code)
 
     return token_name, access_token
 
@@ -155,14 +155,14 @@ def start_device_login(
     return d
 
 
-def check_token_authorization(*, uri: str, device_code: str) -> Optional[str]:
+def check_token_authentication(*, uri: str, device_code: str) -> Optional[str]:
     """
-    Checks the authorization status of a token based on a device code and
-    returns access token upon successful authorization.
+    Checks the authentication status of a token based on a device code and
+    returns access token upon successful authentication.
 
     Parameters:
     - uri (str): The token uri to send the request to.
-    - device_code (str): The device code to check authorization for.
+    - device_code (str): The device code to check authentication for.
 
     Returns:
     - str | None: The access token if authorized, otherwise None.
@@ -172,13 +172,13 @@ def check_token_authorization(*, uri: str, device_code: str) -> Optional[str]:
 
     Example Usage:
     ```
-    token = check_token_authorization(
+    token = check_token_authentication(
         uri="https://example.com/api/", device_code="1234567890"
     )
     if token is not None:
         print("Access token:", token)
     else:
-        print("Authorization expired.")
+        print("Authentication expired.")
     ```
     """
     import time
@@ -204,7 +204,7 @@ def check_token_authorization(*, uri: str, device_code: str) -> Optional[str]:
                 time.sleep(5)
                 continue
             if detail == "authorization_expired":
-                raise AuthorizationExpired(
+                raise AuthenticationExpired(
                     "failed to authenticate: This 'device_code' has expired."
                 )
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,10 +3,10 @@ import requests
 from requests import Response
 
 from dvc_studio_client.auth import (
-    AuthorizationExpired,
+    AuthenticationExpired,
     DeviceLoginResponse,
     InvalidScopesError,
-    check_token_authorization,
+    check_token_authentication,
     get_access_token,
     start_device_login,
 )
@@ -51,7 +51,7 @@ def test_auth_expired(mocker, mock_post):
         "requests.Session.post", [(400, {"detail": "authorization_expired"})]
     )
 
-    with pytest.raises(AuthorizationExpired):
+    with pytest.raises(AuthenticationExpired):
         get_access_token(client_name="client", hostname="https://studio.example.com")
 
     assert mock_login_post.call_args == mocker.call(
@@ -191,8 +191,8 @@ def test_check_token_authorization_expired(mocker, mock_post):
         ],
     )
 
-    with pytest.raises(AuthorizationExpired):
-        check_token_authorization(
+    with pytest.raises(AuthenticationExpired):
+        check_token_authentication(
             uri="https://example.com/token_uri", device_code="random_device_code"
         )
 
@@ -205,7 +205,7 @@ def test_check_token_authorization_expired(mocker, mock_post):
     )
 
 
-def test_check_token_authorization_error(mocker, mock_post):
+def test_check_token_authentication_error(mocker, mock_post):
     mocker.patch("time.sleep")
     mock_post = mock_post(
         "requests.Session.post",
@@ -216,7 +216,7 @@ def test_check_token_authorization_error(mocker, mock_post):
     )
 
     with pytest.raises(requests.RequestException):
-        check_token_authorization(
+        check_token_authentication(
             uri="https://example.com/token_uri", device_code="random_device_code"
         )
 
@@ -229,7 +229,7 @@ def test_check_token_authorization_error(mocker, mock_post):
     )
 
 
-def test_check_token_authorization_success(mocker, mock_post):
+def test_check_token_authentication_success(mocker, mock_post):
     mocker.patch("time.sleep")
     mock_post_call = mock_post(
         "requests.Session.post",
@@ -241,7 +241,7 @@ def test_check_token_authorization_success(mocker, mock_post):
     )
 
     assert (
-        check_token_authorization(
+        check_token_authentication(
             uri="https://example.com/token_uri", device_code="random_device_code"
         )
         == "isat_token"


### PR DESCRIPTION
Renamed all instances of 'Authorization' to 'Authentication' in tests, README and codebase including changing functions, classes, and variables names. The term 'Authentication' is more appropriate in this context as we are verifying the identity of the user, not their access rights.

Related to https://github.com/iterative/studio/issues/8424
