### PR TITLE
Add optional monorepo information into schema and post_live_metrics

### DIFF
--- a/src/dvc_studio_client/post_live_metrics.py
+++ b/src/dvc_studio_client/post_live_metrics.py
@@ -123,6 +123,8 @@ def post_live_metrics(  # noqa: C901,PLR0912,PLR0913
     studio_token: Optional[str] = None,
     studio_repo_url: Optional[str] = None,
     studio_url: Optional[str] = None,
+    dvc_experiment_parent_data: Optional[Dict[str, Any]] = None,
+    subdir: Optional[str] = None,
 ) -> Optional[bool]:
     """Post `event_type` to Studio's `api/live`.
 
@@ -239,6 +241,10 @@ def post_live_metrics(  # noqa: C901,PLR0912,PLR0913
         if message:
             # Cutting the message to match the commit title length limit.
             body["message"] = message[:72]
+        if subdir:
+            body["subdir"] = subdir
+        if dvc_experiment_parent_data:
+            body["dvc_experiment_parent_data"] = dvc_experiment_parent_data
     elif event_type == "data":
         if step is None:
             logger.warning("Missing `step` in `data` event.")

--- a/src/dvc_studio_client/schema.py
+++ b/src/dvc_studio_client/schema.py
@@ -1,4 +1,4 @@
-from voluptuous import All, Any, Exclusive, Lower, Match, Required, Schema
+from voluptuous import All, Any, Exclusive, Lower, Match, Optional, Required, Schema
 
 
 def choices(*choices):
@@ -32,6 +32,8 @@ SCHEMAS_BY_TYPE = {
     "start": BASE_SCHEMA.extend(
         {
             "message": str,
+            Optional("dvc_experiment_parent_data"): dict,
+            Optional("subdir"): str,
         },
     ),
     "data": BASE_SCHEMA.extend(


### PR DESCRIPTION
Part of https://github.com/iterative/studio/issues/8848

Required for https://github.com/iterative/studio/pull/9019 / https://github.com/iterative/dvc/pull/10291 / https://github.com/iterative/dvclive/pull/779

This PR adds additional data into the schema to support live experiments from monorepos being displayed correctly in Studio.

We are adding the following to the start event:

```
    dvc_experiment_parent_data: Optional[Dict[str, Any]] = None,
    subdir: Optional[str] = None,
```

The rest of the `start` event remains unchanged. The names of the new fields match the fields already present in Studio for pushed experiments/commits. They are optional so that we can continue to accept "legacy" events from older versions of the client in Studio.