### PR TITLE
Update leaked secrets workflow

### DIFF
--- a/.github/workflows/leaked-secrets-scan.yaml
+++ b/.github/workflows/leaked-secrets-scan.yaml
@@ -3,7 +3,6 @@ on:
   pull_request:
   push:
     branches:
-      - develop
       - main
       - "[0-9]+.[0-9]+.x"
   workflow_dispatch:
@@ -15,10 +14,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@901c851698ee7d9a8361969246c47d0f88e6d048
+      - name: TruffleHog OSS - PR
+        uses: trufflesecurity/trufflehog@main
         with:
           path: ./
           base: ${{ github.event.repository.default_branch }}
           head: HEAD
           extra_args: --debug --only-verified
+        if: github.ref_name != 'main' && github.event_name != 'release'
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          extra_args: --debug --only-verified
+        if: github.ref_name == 'main' && github.event_name == 'release'


### PR DESCRIPTION
This PR updates the leaked secrets scan workflow to match Studio's

The current workflow is failing against `main`: https://github.com/iterative/dvc-studio-client/actions/runs/7794538633/job/21256042522