### PR TITLE
Revert codecov action to v3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,4 +50,4 @@ jobs:
       run: pytest -v tests --cov --cov-config=pyproject.toml --cov-report=xml
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@v4.0.1
+      uses: codecov/codecov-action@v3

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["config:base"],
+  "ignoreDeps": ["codecov/codecov-action"]
 }


### PR DESCRIPTION
As per [this](https://iterativeai.slack.com/archives/C0209RF6A5B/p1707227969853629) there are breaking changes between the major versions that cannot be supported without some changes to repo/org secrets.