### PR TITLE
simplify verbose message when attempting auth login

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ tests = [
 dev = [
     "dvc-studio-client[tests]",
     "dvc-studio-client[docs]",
+    "types-requests",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
I think the message is too verbose. Also removed `use_device_code` specific logic. Now it'll show a URL with 'device_code' included, instead of requiring user to open a url separately and then copy the code. The `use_device_code` is effectively now `open_browser=False`.

So I'm deprecating it, and introducing `open_browser=True|False` to do just that. But backward compatibility is still maintained to avoid creating a major version release.

[![asciicast](https://asciinema.org/a/T1MUuHg2sOOrRXNOueNMy7J3U.svg)](https://asciinema.org/a/T1MUuHg2sOOrRXNOueNMy7J3U)

Related: https://github.com/iterative/dvc/pull/10297
