### PR TITLE
Add optional monorepo information (subdir) into schema and post_live_metrics

### DIFF
--- a/src/dvc_studio_client/post_live_metrics.py
+++ b/src/dvc_studio_client/post_live_metrics.py
@@ -123,6 +123,7 @@ def post_live_metrics(  # noqa: C901,PLR0912,PLR0913
     studio_token: Optional[str] = None,
     studio_repo_url: Optional[str] = None,
     studio_url: Optional[str] = None,
+    subdir: Optional[str] = None,
 ) -> Optional[bool]:
     """Post `event_type` to Studio's `api/live`.
 
@@ -239,6 +240,8 @@ def post_live_metrics(  # noqa: C901,PLR0912,PLR0913
         if message:
             # Cutting the message to match the commit title length limit.
             body["message"] = message[:72]
+        if subdir:
+            body["subdir"] = subdir
     elif event_type == "data":
         if step is None:
             logger.warning("Missing `step` in `data` event.")

--- a/src/dvc_studio_client/schema.py
+++ b/src/dvc_studio_client/schema.py
@@ -1,4 +1,4 @@
-from voluptuous import All, Any, Exclusive, Lower, Match, Required, Schema
+from voluptuous import All, Any, Exclusive, Lower, Match, Optional, Required, Schema
 
 
 def choices(*choices):
@@ -32,6 +32,7 @@ SCHEMAS_BY_TYPE = {
     "start": BASE_SCHEMA.extend(
         {
             "message": str,
+            Optional("subdir"): str,
         },
     ),
     "data": BASE_SCHEMA.extend(

--- a/tests/test_post_live_metrics.py
+++ b/tests/test_post_live_metrics.py
@@ -38,59 +38,84 @@ def test_post_live_metrics_skip_on_schema_error(caplog, monkeypatch):
 
 
 def test_post_live_metrics_start_event(mocker, monkeypatch):
-    monkeypatch.setenv(DVC_STUDIO_URL, "https://0.0.0.0")
-    monkeypatch.setenv(DVC_STUDIO_TOKEN, "FOO_TOKEN")
-    monkeypatch.setenv(STUDIO_REPO_URL, "FOO_REPO_URL")
+    repo_url = "FOO_REPO_URL"
+    studio_url = "https://0.0.0.0"
+    studio_token = "FOO_TOKEN"
+    baseline_sha = "f" * 40
+    event_type = "start"
+    name = "fooname"
+    client = "fooclient"
+
+    post_url = f"{studio_url}/api/live"
+    headers = {
+        "Authorization": f"token {studio_token}",
+        "Content-type": "application/json",
+    }
+    base_event = {
+        "type": "start",
+        "repo_url": "FOO_REPO_URL",
+        "baseline_sha": baseline_sha,
+        "name": name,
+        "client": client,
+    }
+
+    monkeypatch.setenv(DVC_STUDIO_URL, studio_url)
+    monkeypatch.setenv(DVC_STUDIO_TOKEN, studio_token)
+    monkeypatch.setenv(STUDIO_REPO_URL, repo_url)
 
     mocked_response = mocker.MagicMock()
     mocked_response.status_code = 200
     mocked_post = mocker.patch("requests.post", return_value=mocked_response)
 
     assert post_live_metrics(
-        "start",
-        "f" * 40,
-        "fooname",
-        "fooclient",
+        event_type,
+        baseline_sha,
+        name,
+        client,
     )
 
     mocked_post.assert_called_with(
-        "https://0.0.0.0/api/live",
-        json={
-            "type": "start",
-            "repo_url": "FOO_REPO_URL",
-            "baseline_sha": "f" * 40,
-            "name": "fooname",
-            "client": "fooclient",
-        },
-        headers={
-            "Authorization": "token FOO_TOKEN",
-            "Content-type": "application/json",
-        },
+        post_url,
+        json=base_event,
+        headers=headers,
         timeout=(30, 5),
     )
 
-    post_live_metrics(
-        "start",
-        "f" * 40,
-        "fooname",
-        "fooclient",
+    assert post_live_metrics(
+        event_type,
+        baseline_sha,
+        name,
+        client,
         params={"params.yaml": {"foo": "bar"}},
     )
 
     mocked_post.assert_called_with(
-        "https://0.0.0.0/api/live",
+        post_url,
         json={
-            "type": "start",
-            "repo_url": "FOO_REPO_URL",
-            "baseline_sha": "f" * 40,
-            "name": "fooname",
-            "client": "fooclient",
+            **base_event,
             "params": {"params.yaml": {"foo": "bar"}},
         },
-        headers={
-            "Authorization": "token FOO_TOKEN",
-            "Content-type": "application/json",
+        headers=headers,
+        timeout=(30, 5),
+    )
+
+    subdir = "subdir"
+
+    assert post_live_metrics(
+        "start",
+        baseline_sha,
+        name,
+        client,
+        subdir=subdir,
+    )
+
+    mocked_post.assert_called_with(
+        post_url,
+        json={
+            **base_event,
+            "subdir": subdir,
         },
+        headers=headers,
         timeout=(30, 5),
     )
 


### PR DESCRIPTION
Part of https://github.com/iterative/studio/issues/8848

This PR is a repeat of #144 with `dvc_experiment_parent_data` dropped*.  The only addition to the schema is now an optional subdir field.

*`dvc_experiment_parent_data` has been dropped as the detached experiments problem is taking too long to solve on the Studio side.