### PR TITLE
chore(studio): Update Studio URL to new domain

### DIFF
--- a/src/dvc_studio_client/__init__.py
+++ b/src/dvc_studio_client/__init__.py
@@ -14,4 +14,4 @@ logger.setLevel(
     getenv(DVC_STUDIO_CLIENT_LOGLEVEL, getenv(DVCLIVE_LOGLEVEL, "WARNING")).upper(),
 )
 
-DEFAULT_STUDIO_URL = "https://studio.dvc.ai"
+DEFAULT_STUDIO_URL = "https://studio.datachain.ai"

--- a/src/dvc_studio_client/auth.py
+++ b/src/dvc_studio_client/auth.py
@@ -118,7 +118,7 @@ def start_device_login(
 
     Optional Parameters:
     - base_url: The base URL of the Studio API.
-        If not provided, the default value is "https://studio.dvc.ai".
+        If not provided, the default value is "https://studio.datachain.ai".
     - token_name: The name of the token. If not provided, it defaults to None.
     - scopes: A list of scopes to request. If not provided, it defaults to None.
 
@@ -156,7 +156,7 @@ def start_device_login(
     logger.debug(f"JSON body `{body=}`")
 
     response = requests.post(
-        url=urljoin(base_url or "https://studio.dvc.ai", "api/device-login"),
+        url=urljoin(base_url or "https://studio.datachain.ai", "api/device-login"),
         json=body,
         headers={
             "Content-type": "application/json",

--- a/src/dvc_studio_client/config.py
+++ b/src/dvc_studio_client/config.py
@@ -75,7 +75,7 @@ def get_studio_config(
                 {
                     "token": "mytoken",
                     "repo_url": "git@github.com:iterative/dvc-studio-client.git",
-                    "url": "https://studio.dvc.ai",
+                    "url": "https://studio.datachain.ai",
                 }
     """
     config = {}

--- a/tests/test_post_live_metrics.py
+++ b/tests/test_post_live_metrics.py
@@ -189,7 +189,7 @@ def test_post_live_metrics_data(mocker, monkeypatch):
 
     assert post_live_metrics("data", "f" * 40, "fooname", "fooclient", step=0)
     mocked_post.assert_called_with(
-        "https://studio.dvc.ai/api/live",
+        "https://studio.datachain.ai/api/live",
         json={
             "type": "data",
             "repo_url": "FOO_REPO_URL",
@@ -214,7 +214,7 @@ def test_post_live_metrics_data(mocker, monkeypatch):
         params={"dvclive/params.yaml": {"foo": "bar"}},
     )
     mocked_post.assert_called_with(
-        "https://studio.dvc.ai/api/live",
+        "https://studio.datachain.ai/api/live",
         json={
             "type": "data",
             "repo_url": "FOO_REPO_URL",
@@ -247,7 +247,7 @@ def test_post_live_metrics_data(mocker, monkeypatch):
     mocked_post.assert_has_calls(
         [
             mocker.call(
-                "https://studio.dvc.ai/api/live",
+                "https://studio.datachain.ai/api/live",
                 json={
                     "type": "data",
                     "repo_url": "FOO_REPO_URL",
@@ -266,7 +266,7 @@ def test_post_live_metrics_data(mocker, monkeypatch):
                 timeout=(30, 5),
             ),
             mocker.call(
-                "https://studio.dvc.ai/api/live",
+                "https://studio.datachain.ai/api/live",
                 json={
                     "type": "data",
                     "repo_url": "FOO_REPO_URL",
@@ -305,7 +305,7 @@ def test_post_live_metrics_done(mocker, monkeypatch):
         "fooclient",
     )
     mocked_post.assert_called_with(
-        "https://studio.dvc.ai/api/live",
+        "https://studio.datachain.ai/api/live",
         json={
             "type": "done",
             "repo_url": "FOO_REPO_URL",
@@ -328,7 +328,7 @@ def test_post_live_metrics_done(mocker, monkeypatch):
         experiment_rev="h" * 40,
     )
     mocked_post.assert_called_with(
-        "https://studio.dvc.ai/api/live",
+        "https://studio.datachain.ai/api/live",
         json={
             "type": "done",
             "repo_url": "FOO_REPO_URL",
@@ -352,7 +352,7 @@ def test_post_live_metrics_done(mocker, monkeypatch):
         metrics={"dvclive/metris.json": {"data": {"foo": 1}}},
     )
     mocked_post.assert_called_with(
-        "https://studio.dvc.ai/api/live",
+        "https://studio.datachain.ai/api/live",
         json={
             "type": "done",
             "repo_url": "FOO_REPO_URL",
@@ -550,7 +550,7 @@ def test_post_in_chunks(mocker, monkeypatch):
     mocked_post.assert_has_calls(
         [
             mocker.call(
-                "https://studio.dvc.ai/api/live",
+                "https://studio.datachain.ai/api/live",
                 json={
                     "type": "data",
                     "repo_url": "FOO_REPO_URL",
@@ -569,7 +569,7 @@ def test_post_in_chunks(mocker, monkeypatch):
                 timeout=(30, 5),
             ),
             mocker.call(
-                "https://studio.dvc.ai/api/live",
+                "https://studio.datachain.ai/api/live",
                 json={
                     "type": "data",
                     "repo_url": "FOO_REPO_URL",


### PR DESCRIPTION
The https://studio.dvc.ai is deprecated, and we switched to the new domain https://studio.datachain.ai.

The domain change is backwards compatible. The **older versions** of the `dvc` will still work. 🎉