### PR TITLE
adds team-scoped tokens and configurable expiration

### DIFF
--- a/src/dvc_studio_client/auth.py
+++ b/src/dvc_studio_client/auth.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Optional, TypedDict, Union
+from typing import Any, Optional, TypedDict
 from urllib.parse import urljoin
 
 import requests
@@ -40,6 +40,13 @@ def get_access_token(  # noqa: PLR0913
     open_browser: bool = True,
     post_login_message: Optional[str] = None,
     use_device_code: bool = False,
+    # Team scoping parameters
+    team_names: Optional[list[str]] = None,
+    team_ids: Optional[list[int]] = None,
+    all_teams: Optional[bool] = None,
+    # Expiration parameters
+    expires_in_days: Optional[int] = None,
+    never_expires: Optional[bool] = None,
 ):
     """Initiate Authentication
 
@@ -55,6 +62,15 @@ def get_access_token(  # noqa: PLR0913
             the application requires. Default is empty.
         open_browser (bool): Whether or not to open the browser to authenticate
         client_name (str, optional): Client name
+
+    Team Scoping Parameters:
+        team_names (list[str], optional): List of team names to scope the token to.
+        team_ids (list[int], optional): List of team IDs to scope the token to.
+        all_teams (bool, optional): Grant access to all teams.
+
+    Expiration Parameters:
+        expires_in_days (int, optional): Token lifetime in days.
+        never_expires (bool, optional): Create a token that never expires.
 
     Returns
     -------
@@ -74,6 +90,11 @@ def get_access_token(  # noqa: PLR0913
         base_url=hostname,
         token_name=token_name,
         scopes=scopes.split(",") if scopes else [],
+        team_names=team_names,
+        team_ids=team_ids,
+        all_teams=all_teams,
+        expires_in_days=expires_in_days,
+        never_expires=never_expires,
     )
     verification_uri = response["verification_uri"]
     user_code = response["user_code"]
@@ -103,12 +124,19 @@ def get_access_token(  # noqa: PLR0913
     return token_name, access_token
 
 
-def start_device_login(
+def start_device_login(  # noqa: PLR0913
     *,
     client_name: str,
     base_url: Optional[str] = None,
     token_name: Optional[str] = None,
     scopes: Optional[list[str]] = None,
+    # Team scoping parameters
+    team_names: Optional[list[str]] = None,
+    team_ids: Optional[list[int]] = None,
+    all_teams: Optional[bool] = None,
+    # Expiration parameters
+    expires_in_days: Optional[int] = None,
+    never_expires: Optional[bool] = None,
 ) -> DeviceLoginResponse:
     """This method starts the device login process for Studio.
 
@@ -121,6 +149,15 @@ def start_device_login(
         If not provided, the default value is "https://studio.datachain.ai".
     - token_name: The name of the token. If not provided, it defaults to None.
     - scopes: A list of scopes to request. If not provided, it defaults to None.
+
+    Team Scoping Parameters:
+    - team_names: A list of team names to scope the token to.
+    - team_ids: A list of team IDs to scope the token to.
+    - all_teams: Grant access to all teams.
+
+    Expiration Parameters:
+    - expires_in_days: Token lifetime in days.
+    - never_expires: Create a token that never expires.
 
     Returns
     -------
@@ -145,13 +182,27 @@ def start_device_login(
                 f"Following scopes are not valid: {', '.join(invalid_scopes)}",
             )
 
-    body: dict[str, Union[str, list[str]]] = {"client_name": client_name}
+    body: dict[str, Any] = {"client_name": client_name}
 
     if token_name:
         body["token_name"] = token_name
 
     if scopes:
         body["scopes"] = scopes
+
+    # Add team scoping parameters
+    if team_names:
+        body["team_names"] = team_names
+    if team_ids:
+        body["team_ids"] = team_ids
+    if all_teams is not None:
+        body["all_teams"] = all_teams
+
+    # Add expiration parameters
+    if expires_in_days is not None:
+        body["expires_in_days"] = expires_in_days
+    if never_expires is not None:
+        body["never_expires"] = never_expires
 
     logger.debug(f"JSON body `{body=}`")
 

--- a/src/dvc_studio_client/auth.py
+++ b/src/dvc_studio_client/auth.py
@@ -42,7 +42,6 @@ def get_access_token(  # noqa: PLR0913
     use_device_code: bool = False,
     # Team scoping parameters
     team_names: Optional[list[str]] = None,
-    team_ids: Optional[list[int]] = None,
     all_teams: Optional[bool] = None,
     # Expiration parameters
     expires_in_days: Optional[int] = None,
@@ -65,7 +64,6 @@ def get_access_token(  # noqa: PLR0913
 
     Team Scoping Parameters:
         team_names (list[str], optional): List of team names to scope the token to.
-        team_ids (list[int], optional): List of team IDs to scope the token to.
         all_teams (bool, optional): Grant access to all teams.
 
     Expiration Parameters:
@@ -91,7 +89,6 @@ def get_access_token(  # noqa: PLR0913
         token_name=token_name,
         scopes=scopes.split(",") if scopes else [],
         team_names=team_names,
-        team_ids=team_ids,
         all_teams=all_teams,
         expires_in_days=expires_in_days,
         never_expires=never_expires,
@@ -132,7 +129,6 @@ def start_device_login(  # noqa: PLR0913
     scopes: Optional[list[str]] = None,
     # Team scoping parameters
     team_names: Optional[list[str]] = None,
-    team_ids: Optional[list[int]] = None,
     all_teams: Optional[bool] = None,
     # Expiration parameters
     expires_in_days: Optional[int] = None,
@@ -152,7 +148,6 @@ def start_device_login(  # noqa: PLR0913
 
     Team Scoping Parameters:
     - team_names: A list of team names to scope the token to.
-    - team_ids: A list of team IDs to scope the token to.
     - all_teams: Grant access to all teams.
 
     Expiration Parameters:
@@ -182,6 +177,12 @@ def start_device_login(  # noqa: PLR0913
                 f"Following scopes are not valid: {', '.join(invalid_scopes)}",
             )
 
+    # Validate team access parameters
+    if all_teams is False and not team_names:
+        raise ValueError(  # noqa: TRY003
+            "team_names must be specified when all_teams is False"
+        )
+
     body: dict[str, Any] = {"client_name": client_name}
 
     if token_name:
@@ -193,8 +194,6 @@ def start_device_login(  # noqa: PLR0913
     # Add team scoping parameters
     if team_names:
         body["team_names"] = team_names
-    if team_ids:
-        body["team_ids"] = team_ids
     if all_teams is not None:
         body["all_teams"] = all_teams
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -307,3 +307,72 @@ def test_check_token_authentication_success(mocker, mock_post):
         timeout=5,
         allow_redirects=False,
     )
+
+
+def test_start_device_login_with_new_parameters(mock_post, mocker):
+    """Test start_device_login with team scoping and expiration parameters"""
+    mock_post_obj = mock_post("requests.post", [
+        (200, MOCK_RESPONSE),
+        (200, MOCK_RESPONSE),
+        (200, MOCK_RESPONSE)
+    ])
+
+    start_device_login(client_name="test", team_names=["team1"], expires_in_days=30)
+    start_device_login(client_name="test", team_ids=[1, 2], never_expires=True)
+    start_device_login(client_name="test", all_teams=False)
+
+    assert mock_post_obj.call_args_list == [
+        mocker.call(
+            url="https://studio.datachain.ai/api/device-login",
+            json={"client_name": "test", "team_names": ["team1"], "expires_in_days": 30},
+            headers={"Content-type": "application/json"},
+            timeout=5,
+        ),
+        mocker.call(
+            url="https://studio.datachain.ai/api/device-login",
+            json={"client_name": "test", "team_ids": [1, 2], "never_expires": True},
+            headers={"Content-type": "application/json"},
+            timeout=5,
+        ),
+        mocker.call(
+            url="https://studio.datachain.ai/api/device-login",
+            json={"client_name": "test", "all_teams": False},
+            headers={"Content-type": "application/json"},
+            timeout=5,
+        ),
+    ]
+
+
+def test_get_access_token_parameter_passthrough(mocker, mock_post):
+    """Test get_access_token passes new parameters to start_device_login"""
+    mocker.patch("webbrowser.open")
+    mocker.patch("time.sleep")
+    mock_login_post = mock_post("requests.post", [(200, MOCK_RESPONSE)])
+    mock_post("requests.Session.post", [(200, {"access_token": "token"})])
+
+    get_access_token(hostname="https://example.com", team_names=["team1"], expires_in_days=7)
+
+    assert mock_login_post.call_args == mocker.call(
+        url="https://example.com/api/device-login",
+        json={"client_name": "client", "team_names": ["team1"], "expires_in_days": 7},
+        headers={"Content-type": "application/json"},
+        timeout=5,
+    )
+
+
+def test_backwards_compatibility(mocker, mock_post):
+    """Test existing calls work unchanged"""
+    mocker.patch("webbrowser.open")
+    mocker.patch("time.sleep")
+    mock_login_post = mock_post("requests.post", [(200, MOCK_RESPONSE)])
+    mock_post("requests.Session.post", [(200, {"access_token": "token"})])
+
+    token_name, access_token = get_access_token(hostname="https://example.com", scopes="experiments")
+
+    assert (token_name, access_token) == ("random-name", "token")
+    assert mock_login_post.call_args == mocker.call(
+        url="https://example.com/api/device-login",
+        json={"client_name": "client", "scopes": ["experiments"]},
+        headers={"Content-type": "application/json"},
+        timeout=5,
+    )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -311,11 +311,10 @@ def test_check_token_authentication_success(mocker, mock_post):
 
 def test_start_device_login_with_new_parameters(mock_post, mocker):
     """Test start_device_login with team scoping and expiration parameters"""
-    mock_post_obj = mock_post("requests.post", [
-        (200, MOCK_RESPONSE),
-        (200, MOCK_RESPONSE),
-        (200, MOCK_RESPONSE)
-    ])
+    mock_post_obj = mock_post(
+        "requests.post",
+        [(200, MOCK_RESPONSE), (200, MOCK_RESPONSE), (200, MOCK_RESPONSE)],
+    )
 
     start_device_login(client_name="test", team_names=["team1"], expires_in_days=30)
     start_device_login(client_name="test", team_ids=[1, 2], never_expires=True)
@@ -324,7 +323,11 @@ def test_start_device_login_with_new_parameters(mock_post, mocker):
     assert mock_post_obj.call_args_list == [
         mocker.call(
             url="https://studio.datachain.ai/api/device-login",
-            json={"client_name": "test", "team_names": ["team1"], "expires_in_days": 30},
+            json={
+                "client_name": "test",
+                "team_names": ["team1"],
+                "expires_in_days": 30,
+            },
             headers={"Content-type": "application/json"},
             timeout=5,
         ),
@@ -350,7 +353,9 @@ def test_get_access_token_parameter_passthrough(mocker, mock_post):
     mock_login_post = mock_post("requests.post", [(200, MOCK_RESPONSE)])
     mock_post("requests.Session.post", [(200, {"access_token": "token"})])
 
-    get_access_token(hostname="https://example.com", team_names=["team1"], expires_in_days=7)
+    get_access_token(
+        hostname="https://example.com", team_names=["team1"], expires_in_days=7
+    )
 
     assert mock_login_post.call_args == mocker.call(
         url="https://example.com/api/device-login",
@@ -367,7 +372,9 @@ def test_backwards_compatibility(mocker, mock_post):
     mock_login_post = mock_post("requests.post", [(200, MOCK_RESPONSE)])
     mock_post("requests.Session.post", [(200, {"access_token": "token"})])
 
-    token_name, access_token = get_access_token(hostname="https://example.com", scopes="experiments")
+    token_name, access_token = get_access_token(
+        hostname="https://example.com", scopes="experiments"
+    )
 
     assert (token_name, access_token) == ("random-name", "token")
     assert mock_login_post.call_args == mocker.call(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -313,12 +313,11 @@ def test_start_device_login_with_new_parameters(mock_post, mocker):
     """Test start_device_login with team scoping and expiration parameters"""
     mock_post_obj = mock_post(
         "requests.post",
-        [(200, MOCK_RESPONSE), (200, MOCK_RESPONSE), (200, MOCK_RESPONSE)],
+        [(200, MOCK_RESPONSE), (200, MOCK_RESPONSE)],
     )
 
     start_device_login(client_name="test", team_names=["team1"], expires_in_days=30)
-    start_device_login(client_name="test", team_ids=[1, 2], never_expires=True)
-    start_device_login(client_name="test", all_teams=False)
+    start_device_login(client_name="test", all_teams=False, team_names=["team1"])
 
     assert mock_post_obj.call_args_list == [
         mocker.call(
@@ -333,13 +332,7 @@ def test_start_device_login_with_new_parameters(mock_post, mocker):
         ),
         mocker.call(
             url="https://studio.datachain.ai/api/device-login",
-            json={"client_name": "test", "team_ids": [1, 2], "never_expires": True},
-            headers={"Content-type": "application/json"},
-            timeout=5,
-        ),
-        mocker.call(
-            url="https://studio.datachain.ai/api/device-login",
-            json={"client_name": "test", "all_teams": False},
+            json={"client_name": "test", "all_teams": False, "team_names": ["team1"]},
             headers={"Content-type": "application/json"},
             timeout=5,
         ),
@@ -383,3 +376,22 @@ def test_backwards_compatibility(mocker, mock_post):
         headers={"Content-type": "application/json"},
         timeout=5,
     )
+
+
+def test_start_device_login_validation_all_teams_false_without_team_names():
+    """Test validation error when all_teams=False but team_names not provided"""
+    with pytest.raises(
+        ValueError, match="team_names must be specified when all_teams is False"
+    ):
+        start_device_login(client_name="test", all_teams=False)
+
+
+def test_start_device_login_validation_all_teams_false_with_team_names(mock_post):
+    """Test that all_teams=False works when team_names is provided"""
+    mock_post("requests.post", [(200, MOCK_RESPONSE)])
+
+    # This should work without raising an error
+    result = start_device_login(
+        client_name="test", all_teams=False, team_names=["team1"]
+    )
+    assert result == MOCK_RESPONSE


### PR DESCRIPTION
Companion to datachain-ai/studio#12918 which adds team-scoped tokens and configurable expiration on the backend side.

Wires up the new parameters in start_device_login and get_access_token so callers can use them:
- team_names / team_ids / all_teams for scoping the token to specific teams
- expires_in_days and never_expires for controlling token lifetime

All new params are optional so nothing breaks for existing callers. Validation stays server-side since the backend already handles that.
